### PR TITLE
모임방 별 정산내역 요약 조회 mock API 작성

### DIFF
--- a/src/main/java/com/core/backend/common/mock/GetGroupSettlementMockData.java
+++ b/src/main/java/com/core/backend/common/mock/GetGroupSettlementMockData.java
@@ -1,0 +1,126 @@
+package com.core.backend.common.mock;
+
+import com.core.backend.group.ui.dto.GroupMemberResponse;
+import com.core.backend.group.ui.dto.GroupSettlementListResponse;
+import com.core.backend.group.ui.dto.GroupSettlementResponse;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class GetGroupSettlementMockData {
+
+    public static final Map<Long, GroupSettlementResponse> groupDataMap = new HashMap<>();
+
+    static {
+        groupDataMap.put(1L, mockDataForGroup1());
+        groupDataMap.put(2L, mockDataForGroup2());
+        groupDataMap.put(3L, mockDataForGroup3());
+    }
+
+    public static GroupSettlementResponse mockDataForGroup1() {
+        List<GroupMemberResponse> memberResponseList = getGroupMemberResponsesForGroup1();
+        List<GroupSettlementListResponse> settlementList = getGroupSettlementListResponsesForGroup1();
+        return new GroupSettlementResponse(memberResponseList, settlementList);
+    }
+
+    public static GroupSettlementResponse mockDataForGroup2() {
+        List<GroupMemberResponse> memberResponseList = getGroupMemberResponsesForGroup2();
+        List<GroupSettlementListResponse> settlementList = getGroupSettlementListResponsesForGroup2();
+        return new GroupSettlementResponse(memberResponseList, settlementList);
+    }
+
+    public static GroupSettlementResponse mockDataForGroup3() {
+        List<GroupMemberResponse> memberResponseList = getGroupMemberResponsesForGroup3();
+        List<GroupSettlementListResponse> settlementList = getGroupSettlementListResponsesForGroup3();
+        return new GroupSettlementResponse(memberResponseList, settlementList);
+    }
+
+    private static List<GroupSettlementListResponse> getGroupSettlementListResponsesForGroup1() {
+        GroupSettlementListResponse settlementResponse1 = new GroupSettlementListResponse(
+                1L, "1차 회식", 70000, LocalDate.of(2024, 5, 12)
+        );
+        GroupSettlementListResponse settlementResponse2 = new GroupSettlementListResponse(
+                2L, "2차 회식", 80000, LocalDate.of(2024, 5, 12)
+        );
+        GroupSettlementListResponse settlementResponse3 = new GroupSettlementListResponse(
+                3L, "3차 회식", 90000, LocalDate.of(2024, 5, 12)
+        );
+
+        return List.of(settlementResponse1, settlementResponse2, settlementResponse3);
+    }
+
+    private static List<GroupMemberResponse> getGroupMemberResponsesForGroup1() {
+        GroupMemberResponse memberResponse1 = new GroupMemberResponse(
+                1L, "민선"
+        );
+        GroupMemberResponse memberResponse2 = new GroupMemberResponse(
+                2L, "나은"
+        );
+        GroupMemberResponse memberResponse3 = new GroupMemberResponse(
+                3L, "해성"
+        );
+        GroupMemberResponse memberResponse4 = new GroupMemberResponse(
+                4L, "한비"
+        );
+        GroupMemberResponse memberResponse5 = new GroupMemberResponse(
+                5L, "나영"
+        );
+        GroupMemberResponse memberResponse6 = new GroupMemberResponse(
+                6L, "건"
+        );
+
+        return List.of(memberResponse1, memberResponse2, memberResponse3, memberResponse4, memberResponse5, memberResponse6);
+    }
+
+    private static List<GroupSettlementListResponse> getGroupSettlementListResponsesForGroup2() {
+        GroupSettlementListResponse settlementResponse1 = new GroupSettlementListResponse(
+                4L, "첫 모임", 60000, LocalDate.of(2024, 6, 23)
+        );
+        GroupSettlementListResponse settlementResponse2 = new GroupSettlementListResponse(
+                5L, "두 번째 모임", 70000, LocalDate.of(2024, 6, 23)
+        );
+
+        return List.of(settlementResponse1, settlementResponse2);
+    }
+
+    private static List<GroupMemberResponse> getGroupMemberResponsesForGroup2() {
+        GroupMemberResponse memberResponse1 = new GroupMemberResponse(
+                1L, "민선"
+        );
+        GroupMemberResponse memberResponse2 = new GroupMemberResponse(
+                8L, "영희"
+        );
+        GroupMemberResponse memberResponse3 = new GroupMemberResponse(
+                9L, "길동"
+        );
+
+        return List.of(memberResponse1, memberResponse2, memberResponse3);
+    }
+
+    private static List<GroupSettlementListResponse> getGroupSettlementListResponsesForGroup3() {
+        GroupSettlementListResponse settlementResponse1 = new GroupSettlementListResponse(
+                6L, "팀 회의", 50000, LocalDate.of(2024, 7, 1)
+        );
+        GroupSettlementListResponse settlementResponse2 = new GroupSettlementListResponse(
+                7L, "팀 디너", 60000, LocalDate.of(2024, 7, 1)
+        );
+
+        return List.of(settlementResponse1, settlementResponse2);
+    }
+
+    private static List<GroupMemberResponse> getGroupMemberResponsesForGroup3() {
+        GroupMemberResponse memberResponse1 = new GroupMemberResponse(
+                1L, "민선"
+        );
+        GroupMemberResponse memberResponse2 = new GroupMemberResponse(
+                11L, "정훈"
+        );
+        GroupMemberResponse memberResponse3 = new GroupMemberResponse(
+                12L, "상현"
+        );
+
+        return List.of(memberResponse1, memberResponse2, memberResponse3);
+    }
+}

--- a/src/main/java/com/core/backend/group/ui/GroupController.java
+++ b/src/main/java/com/core/backend/group/ui/GroupController.java
@@ -1,13 +1,17 @@
 package com.core.backend.group.ui;
 
 import com.core.backend.common.mock.GetAllGroupMockData;
+import com.core.backend.common.mock.GetGroupSettlementMockData;
 import com.core.backend.common.repsonse.ResultResponse;
 import com.core.backend.group.ui.dto.GroupInfoResponse;
+import com.core.backend.group.ui.dto.GroupSettlementResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,5 +23,13 @@ public class GroupController {
         List<GroupInfoResponse> responses = GetAllGroupMockData.MockData();
 
         return ResultResponse.success(responses);
+    }
+
+    @GetMapping("/groups/{groupsId}")
+    public ResultResponse<GroupSettlementResponse> getGroupSettlements(@PathVariable Long groupsId) {
+        Map<Long, GroupSettlementResponse> groupDataMap = GetGroupSettlementMockData.groupDataMap;
+        GroupSettlementResponse response = groupDataMap.get(groupsId);
+
+        return ResultResponse.success(response);
     }
 }

--- a/src/main/java/com/core/backend/group/ui/dto/GroupMemberResponse.java
+++ b/src/main/java/com/core/backend/group/ui/dto/GroupMemberResponse.java
@@ -1,0 +1,15 @@
+package com.core.backend.group.ui.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class GroupMemberResponse {  
+  
+    private Long id;  
+    private String name;  
+}

--- a/src/main/java/com/core/backend/group/ui/dto/GroupSettlementListResponse.java
+++ b/src/main/java/com/core/backend/group/ui/dto/GroupSettlementListResponse.java
@@ -1,0 +1,19 @@
+package com.core.backend.group.ui.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class GroupSettlementListResponse {  
+  
+    private Long id;  
+    private String name;
+    private int totalPaymentAmount;
+    private LocalDate settlementAt;
+}

--- a/src/main/java/com/core/backend/group/ui/dto/GroupSettlementResponse.java
+++ b/src/main/java/com/core/backend/group/ui/dto/GroupSettlementResponse.java
@@ -1,0 +1,18 @@
+package com.core.backend.group.ui.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class GroupSettlementResponse {  
+  
+    private List<GroupMemberResponse> groupMembers;
+    private List<GroupSettlementListResponse> settlements;  
+  
+}


### PR DESCRIPTION
- 모임방 별 정산내역 요약 조회 mock Data 생성
- 모임방 별 정산내역 요약 조회 mock API 작성


> 모임방 조회 화면에 사용하는 mock API는 5개인데 반해 현재 만들어진 mockData는 1~3번까지의 데이터입니다.
> 연관되어 있는 데이터가 많아 3번까지 생성했는데 merge 후 모임방 조회 mockData도 맞춰서 3개로 줄일 예정입니다.