### PR TITLE
참여자의 정산 동의 여부에 따른 포인트 정산 결제 기능 API 작성

### DIFF
--- a/src/main/java/com/core/backend/account/domain/Account.java
+++ b/src/main/java/com/core/backend/account/domain/Account.java
@@ -52,7 +52,7 @@ public class Account {
     }
 
     public boolean validateSufficientBalance(Long amount) {
-        return this.balance >= amount;
+        return this.balance < amount;
     }
 
     public void decreaseBalance(Long amount) {
@@ -60,7 +60,7 @@ public class Account {
             throw new AccountException(ErrorCode.ERROR_AMOUNT_TOO_LOW);
         }
 
-        if(!validateSufficientBalance(amount)) {
+        if(validateSufficientBalance(amount)) {
             throw new AccountException(ErrorCode.INSUFFICIENT_BALANCE);
         }
 

--- a/src/main/java/com/core/backend/account/domain/repository/AccountRepository.java
+++ b/src/main/java/com/core/backend/account/domain/repository/AccountRepository.java
@@ -13,4 +13,6 @@ public interface AccountRepository {
 	boolean existsByUserIdAndMainAccountTrue(final Long userId);
 
 	Account findByUserId(final Long userId);
+
+	Account findByUserIdAndMainAccountTrue(Long userId);
 }

--- a/src/main/java/com/core/backend/account/infra/AccountRepositoryImpl.java
+++ b/src/main/java/com/core/backend/account/infra/AccountRepositoryImpl.java
@@ -41,4 +41,10 @@ public class AccountRepositoryImpl implements AccountRepository {
 		return repository.findByUserId(userId)
 			.orElseThrow(() -> new AccountException(ErrorCode.NOT_FOUND_ACCOUNT));
 	}
+
+	@Override
+	public Account findByUserIdAndMainAccountTrue(Long userId) {
+		return repository.findByUserIdAndMainAccountTrue(userId)
+			.orElseThrow(() -> new AccountException(ErrorCode.NOT_FOUND_MAIN_ACCOUNT));
+	}
 }

--- a/src/main/java/com/core/backend/account/infra/JpaAccountRepository.java
+++ b/src/main/java/com/core/backend/account/infra/JpaAccountRepository.java
@@ -15,4 +15,6 @@ public interface JpaAccountRepository extends JpaRepository<Account, Long> {
 	boolean existsByUserIdAndMainAccountTrue(final Long userId);
 
 	Optional<Account> findByUserId(Long userId);
+
+	Optional<Account> findByUserIdAndMainAccountTrue(Long userId);
 }

--- a/src/main/java/com/core/backend/common/exception/ErrorCode.java
+++ b/src/main/java/com/core/backend/common/exception/ErrorCode.java
@@ -17,8 +17,10 @@ public enum ErrorCode {
 	INSUFFICIENT_BALANCE(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.value(), "계좌 잔액이 충분하지 않습니다."),
 	INSUFFICIENT_POINT(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.value(), "보유 포인트가 충분하지 않습니다."),
 	ERROR_AMOUNT_TOO_LOW(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.value(), "환전 금액은 1만원 이상이어야 합니다"),
+	PARTICIPANT_AGREEMENT_MISSING(HttpStatus.BAD_REQUEST, HttpStatus.BAD_REQUEST.value(), "참가자의 동의가 부족합니다."),
 
 	NOT_FOUND_ACCOUNT(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당하는 계좌 정보가 존재하지 않습니다"),
+	NOT_FOUND_MAIN_ACCOUNT(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "대표 결제계좌 정보가 존재하지 않습니다"),
 	NOT_FOUND_POINT_INFO(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당하는 포인트 정보가 존재하지 않습니다"),
 	NOT_FOUND_SETTLEMENT(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "해당하는 정산 정보가 존재하지 않습니다"),
 	BANK_IS_NOT_FOUND(HttpStatus.NOT_FOUND, HttpStatus.NOT_FOUND.value(), "일치하는 은행이 없습니다."),

--- a/src/main/java/com/core/backend/group/ui/GroupController.java
+++ b/src/main/java/com/core/backend/group/ui/GroupController.java
@@ -43,7 +43,7 @@ public class GroupController {
 		CreateGroupResponse response =
 			groupCommandService.createGroup(authUser.getUserId(), GroupRegisterServiceRequest.from(request.getGroupName()));
 
-		return ResultResponse.success();
+		return ResultResponse.success(response);
 	}
 
 	@GetMapping("/groups")

--- a/src/main/java/com/core/backend/point/application/PointCommandService.java
+++ b/src/main/java/com/core/backend/point/application/PointCommandService.java
@@ -25,7 +25,7 @@ public class PointCommandService {
 	private final PointRepository pointRepository;
 
 	public PointConversionResponse convertBalanceToPoints(Long userId, PointConversionServiceRequest request) {
-		Account account = accountRepository.findByUserId(userId);
+		Account account = accountRepository.findByUserIdAndMainAccountTrue(userId);
 		validateBalance(request, account);
 
 		account.decreaseBalance(request.getAmount());
@@ -37,7 +37,7 @@ public class PointCommandService {
 	}
 
 	private void validateBalance(PointConversionServiceRequest request, Account account) {
-		if(!account.validateSufficientBalance(request.getAmount())) {
+		if(account.validateSufficientBalance(request.getAmount())) {
 			throw new AccountException(ErrorCode.INSUFFICIENT_BALANCE);
 		}
 	}

--- a/src/main/java/com/core/backend/point/domain/Point.java
+++ b/src/main/java/com/core/backend/point/domain/Point.java
@@ -39,10 +39,34 @@ public class Point {
 	}
 
 	public void increasePoint(Long amount) {
-		if (amount == null || amount > 10000) { // TODO : 최소 환전 금액 기준 세우기(일단 1만원으로 설정함)
+		if (amount == null || amount < 10000) { // TODO : 최소 환전 금액 기준 세우기(일단 1만원으로 설정함)
 			throw new AccountException(ErrorCode.ERROR_AMOUNT_TOO_LOW);
 		}
 
 		this.point += amount;
+	}
+
+	public void decreasePoint(Long amount) {
+		if (amount == null || amount < 10000) { // TODO : 최소 환전 금액 기준 세우기(일단 1만원으로 설정함)
+			throw new AccountException(ErrorCode.ERROR_AMOUNT_TOO_LOW);
+		}
+
+		if(validateSufficientPoint(amount)) {
+			throw new AccountException(ErrorCode.INSUFFICIENT_POINT);
+		}
+
+		this.point -= amount;
+	}
+
+	public void processSettlement(Long amount) {
+		if(validateSufficientPoint(amount)) {
+			throw new AccountException(ErrorCode.INSUFFICIENT_POINT);
+		}
+
+		this.point -= amount;
+	}
+
+	public boolean validateSufficientPoint(Long amount) {
+		return this.point < amount;
 	}
 }

--- a/src/main/java/com/core/backend/settlement/domain/Settlement.java
+++ b/src/main/java/com/core/backend/settlement/domain/Settlement.java
@@ -88,4 +88,10 @@ public class Settlement {
 			this.settlementStatus = SettlementStatus.IN_PROGRESS;
 		}
 	}
+
+	public void completeSettlement() {
+		if (this.settlementStatus.equals(SettlementStatus.OPEN)) {
+			this.settlementStatus = SettlementStatus.SUCCESS;
+		}
+	}
 }

--- a/src/main/java/com/core/backend/settlement/ui/SettlementController.java
+++ b/src/main/java/com/core/backend/settlement/ui/SettlementController.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -16,6 +15,7 @@ import com.core.backend.common.repsonse.ResultResponse;
 import com.core.backend.settlement.application.SettlementCommandService;
 import com.core.backend.settlement.application.SettlementQueryService;
 import com.core.backend.settlement.application.dto.SettlementRegisterServiceRequest;
+import com.core.backend.settlement.ui.dto.CompletedSettlementResponse;
 import com.core.backend.settlement.ui.dto.RequestedSettlementResponse;
 import com.core.backend.settlement.ui.dto.SettlementDetailResponse;
 import com.core.backend.settlement.ui.dto.SettlementParticipantResponse;
@@ -69,5 +69,16 @@ public class SettlementController {
 		return Optional.ofNullable(settlementQueryService.getRequestedSettlement(authUser.getUserId()))
 			.map(response -> ResultResponse.success(response))
 			.orElseGet(() -> ResultResponse.success());
+	}
+
+	@PostMapping("/settlements/{settlementId}")
+	@Operation(summary = "요청받은 정산 내역 조회 api", description = "요청받은 정산 내역 정보를 조회한다.")
+	ResultResponse<CompletedSettlementResponse> processSettlement(
+		@Authenticated AuthUser authUser,
+		@PathVariable Long settlementId) {
+		CompletedSettlementResponse response = settlementCommandService
+			.processSettlement(authUser.getUserId(), settlementId);
+
+		return ResultResponse.success(response);
 	}
 }

--- a/src/main/java/com/core/backend/settlement/ui/dto/CompletedSettlementResponse.java
+++ b/src/main/java/com/core/backend/settlement/ui/dto/CompletedSettlementResponse.java
@@ -1,0 +1,21 @@
+package com.core.backend.settlement.ui.dto;
+
+import com.core.backend.settlement.domain.Settlement;
+import com.core.backend.settlement.domain.SettlementStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class CompletedSettlementResponse {
+	private Long settlementId;
+	private SettlementStatus settlementStatus;
+
+	public static CompletedSettlementResponse from(Settlement settlement) {
+		return new CompletedSettlementResponse(settlement.getId(), settlement.getSettlementStatus());
+	}
+}

--- a/src/test/java/com/core/backend/settlement/application/SettlementCommandServiceTest.java
+++ b/src/test/java/com/core/backend/settlement/application/SettlementCommandServiceTest.java
@@ -52,6 +52,18 @@ class SettlementCommandServiceTest extends SettlementServiceTestFixture {
 		Assertions.assertThat(agreedParticipant.isAgreementStatus()).isTrue();
 	}
 
+	// @Test
+	// @DisplayName("모든 참여자가 동의할 경우 정산이 이루어진다.")
+	// void test() {
+	//     // given
+	//
+	//
+	//     // when
+	//
+	//
+	//     // then
+	// }
+
 	private SettlementRegisterServiceRequest getSettlementRegisterServiceRequest() {
 		SettlementParticipantServiceRequest request1 = new SettlementParticipantServiceRequest(
 			user1.getId(), user1.getName(), 10000L);


### PR DESCRIPTION
- 참여자의 정산 동의 여부에 따른 포인트 정산 결제 기능 API 작성

- 보완 사항 : 정산 과정에서 point가 부족할 경우 예외가 아닌 대표계좌로부터 포인트 환전 후 결제 프로세스 이행 로직 작성 필요