### PR TITLE
논리 삭제에 대비한 도메인별 조회 조건 추가

### DIFF
--- a/src/main/java/com/core/backend/account/domain/Account.java
+++ b/src/main/java/com/core/backend/account/domain/Account.java
@@ -1,10 +1,24 @@
 package com.core.backend.account.domain;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
 import com.core.backend.account.exception.AccountException;
 import com.core.backend.common.entity.BaseEntity;
 import com.core.backend.common.exception.ErrorCode;
 import com.core.backend.user.domain.User;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +27,7 @@ import lombok.Setter;
 @Entity
 @Getter
 @Table(name = "account")
+@SQLRestriction("status = 'ACTIVE'")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Account extends BaseEntity {
 

--- a/src/main/java/com/core/backend/common/entity/BaseEntity.java
+++ b/src/main/java/com/core/backend/common/entity/BaseEntity.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;

--- a/src/main/java/com/core/backend/common/mock/data/GetGroupSettlementDetailMockData.java
+++ b/src/main/java/com/core/backend/common/mock/data/GetGroupSettlementDetailMockData.java
@@ -108,9 +108,8 @@ public class GetGroupSettlementDetailMockData {
 		for (int i = 0; i < members.size(); i++) {
 			GroupParticipantResponse member = members.get(i);
 			long amount = baseAmount + (i < remainder ? 1 : 0);
-			responses.add(new GroupParticipantResponse(member.getId(), member.getName(), amount));
+			responses.add(new GroupParticipantResponse(member.getId(), member.getParticipantName(), amount));
 		}
 		return responses;
 	}
-
 }

--- a/src/main/java/com/core/backend/group/domain/Group.java
+++ b/src/main/java/com/core/backend/group/domain/Group.java
@@ -4,6 +4,8 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import com.core.backend.common.entity.BaseEntity;
 import com.core.backend.settlement.domain.Settlement;
 import com.core.backend.settlement.domain.SettlementStatus;
@@ -27,6 +29,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "`group`")
+@SQLRestriction("status = 'ACTIVE'")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Group extends BaseEntity {
 

--- a/src/main/java/com/core/backend/participant/domain/Participant.java
+++ b/src/main/java/com/core/backend/participant/domain/Participant.java
@@ -1,5 +1,7 @@
 package com.core.backend.participant.domain;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import com.core.backend.settlement.domain.Settlement;
 import com.core.backend.user.domain.User;
 
@@ -20,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "participant", uniqueConstraints = @UniqueConstraint(columnNames = {"settlement_id", "user_id"}))
+@SQLRestriction("status = 'ACTIVE'")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Participant {
 

--- a/src/main/java/com/core/backend/point/domain/Point.java
+++ b/src/main/java/com/core/backend/point/domain/Point.java
@@ -1,5 +1,7 @@
 package com.core.backend.point.domain;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import com.core.backend.account.exception.AccountException;
 import com.core.backend.common.entity.BaseEntity;
 import com.core.backend.common.exception.ErrorCode;
@@ -20,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "point")
+@SQLRestriction("status = 'ACTIVE'")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Point extends BaseEntity {
 

--- a/src/main/java/com/core/backend/settlement/domain/Settlement.java
+++ b/src/main/java/com/core/backend/settlement/domain/Settlement.java
@@ -2,6 +2,8 @@ package com.core.backend.settlement.domain;
 
 import java.time.LocalDate;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import com.core.backend.group.domain.Group;
 import com.core.backend.settlement.application.dto.SettlementRegisterServiceRequest;
 
@@ -24,6 +26,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @Table(name = "settlement")
+@SQLRestriction("status = 'ACTIVE'")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Settlement {
 

--- a/src/main/java/com/core/backend/user/domain/User.java
+++ b/src/main/java/com/core/backend/user/domain/User.java
@@ -23,9 +23,12 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.SQLRestriction;
+
 @Entity
 @Getter
 @Table(name = "`user`")
+@SQLRestriction("status = 'ACTIVE'")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 

--- a/src/main/java/com/core/backend/usergroup/domain/UserGroup.java
+++ b/src/main/java/com/core/backend/usergroup/domain/UserGroup.java
@@ -1,5 +1,7 @@
 package com.core.backend.usergroup.domain;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import com.core.backend.common.entity.BaseEntity;
 import com.core.backend.group.domain.Group;
 import com.core.backend.user.domain.User;
@@ -19,6 +21,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@SQLRestriction("status = 'ACTIVE'")
 @Table(name = "user_group", uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "group_id"}))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserGroup extends BaseEntity {


### PR DESCRIPTION
- @SQLRestriction("status = 'ACTIVE'") 사용해 ACTIVE인 데이터만 조회되도록 개선